### PR TITLE
fix: Unblock password security feature (closes #3)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -152,8 +152,9 @@
 5. Separate API calls for extraction and response double the wait time
 6. User alias consistency between web and bot is critical for shared data
 
-### 27. Password Security Feature Unblocked
+### 27. Password Security Feature Unblocked ✅ **DONE**
 **User Report:** "What is going on in the project now??? I can use the bot while I have not created the password. Moreover, I still may open the web app without password."
+**GitHub Issue:** #3
 **Root Causes:**
 1. Caddyfile had invalid syntax: `${CADDY_DOMAIN:-localhost}` (Caddy doesn't support env var syntax in site blocks)
 2. Backend Dockerfile missing `passlib[bcrypt]` dependency (was in pyproject.toml but not in pip install command)


### PR DESCRIPTION
## Summary\n\nFixes all blockers preventing password security feature from working.\n\n## Changes\n- Fixed Caddyfile syntax error\n- Updated Dockerfile with passlib[bcrypt] and bcrypt==4.0.1\n- Fixed .env variable names (QWEN → MISTRAL)\n- Verified password hashing/verification\n\nCloses #3